### PR TITLE
avoid dplyr_error class

### DIFF
--- a/tests/testthat/test-getters.R
+++ b/tests/testthat/test-getters.R
@@ -55,12 +55,12 @@ test_that('as_sfn_data_multi helper works as intended', {
 test_that('.write_sfn_metadata writes correctly the file', {
 
   #testthat::skip_on_cran()
-  
+
   folder <- tempdir()
   save(ARG_TRE, file = file.path(folder, 'ARG_TRE.RData'))
   save(ARG_MAZ, file = file.path(folder, 'ARG_MAZ.RData'))
   save(AUS_CAN_ST2_MIX, file = file.path(folder, 'AUS_CAN_ST2_MIX.RData'))
-  
+
   sfn_metadata <- sapfluxnetr:::.write_metadata_cache(folder, .dry = TRUE)
 
   expect_false(file.exists(file.path(folder, '.metadata_cache.RData')))
@@ -177,8 +177,7 @@ test_that('filter_sites_by_md combines all metadata correctly', {
   #   'env_nonexistentname'
   # )
   expect_error(
-    filter_sites_by_md(sites, sfn_metadata_ex, !!!filters),
-    class = 'dplyr_error'
+    filter_sites_by_md(sites, sfn_metadata_ex, !!!filters)
     # 'env_nonexistentname'
   )
 
@@ -188,17 +187,17 @@ test_that('filter_sites_by_md combines all metadata correctly', {
 
 #### sfn_sites_in_folder ####
 test_that('sfn_sites_in_folder returns the expected results', {
-  
+
   expect_true(is.character(sfn_sites_in_folder('Data')))
   expect_length(sfn_sites_in_folder('Data'), 3)
   expect_identical(
     sfn_sites_in_folder('Data'), c('ARG_MAZ', 'ARG_TRE', 'AUS_CAN_ST2_MIX')
   )
-  
+
   # errors
   expect_error(sfn_sites_in_folder('NonExistentFolder'))
   expect_error(sfn_sites_in_folder(53))
-  
+
 })
 
 #### teardown


### PR DESCRIPTION
In dplyr 1.0.8, which we are about to release, we no longer mark errors with the "dplyr_error" class.

Please consider releasing with this fix so that this package does not get this error: 

````
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-getters.R:179:3): filter_sites_by_md combines all metadata correctly ──
`filter_sites_by_md(...)` threw an error with unexpected class.
Expected class: dplyr_error
Actual class:   rlang_error/error/condition
Message:        Problem while computing `..1 = env_nonexistentname == "Above canopy"`.
Backtrace:
     ▆
  1. ├─testthat::expect_error(...) at test-getters.R:179:2
  2. │ └─testthat:::quasi_capture(...)
  3. │   ├─testthat .capture(...)
  4. │   │ └─base::withCallingHandlers(...)
  5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  6. ├─sapfluxnetr::filter_sites_by_md(...)
  7. │ └─... %>% unique()
  8. ├─base::unique(.)
  9. ├─dplyr::pull(., .data$si_code)
 10. ├─dplyr::filter(., !!!md_dots)
 11. └─dplyr:::filter.data.frame(., !!!md_dots)
 12.   └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
 13.     └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
 14.       ├─base::withCallingHandlers(...)
 15.       └─mask$eval_all_filter(dots, env_filter)

[ FAIL 1 | WARN 0 | SKIP 19 | PASS 350 ]
Error: Test failures
Execution halted

1 error x | 0 warnings ✓ | 1 note x
````